### PR TITLE
HARD FORK - Aug 2015 - Reduce Time Drift to 30 seconds

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -44,6 +44,8 @@ inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONE
 // Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 
+static const unsigned int FORK_TIME = 1438444800; // Sat, 01 Aug 2015 16:00:00 GMT
+
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;
 #else
@@ -53,7 +55,13 @@ static const int fHaveUPnP = false;
 static const uint256 hashGenesisBlockOfficial("0xaf4ac34e7ef10a08fe2ba692eb9a9c08cf7e89fcf352f9ea6f0fd73ba3e5d03c");
 static const uint256 hashGenesisBlockTestNet ("0xaf4ac34e7ef10a08fe2ba692eb9a9c08cf7e89fcf352f9ea6f0fd73ba3e5d03c");
 
-static const int64 nMaxClockDrift = 2 * 60 * 60;        // two hours
+inline int64 GetClockDrift(int64 nTime)
+{
+	if(nTime < FORK_TIME)
+		return 2 * 60 * 60;
+	else
+		return 30;
+}
 
 extern CScript COINBASE_FLAGS;
 
@@ -1411,7 +1419,7 @@ public:
 
     uint256 GetBlockHash() const
     {
-		if (fUseFastIndex && (nTime < GetAdjustedTime() - 12 * nMaxClockDrift) && blockHash != 0)
+		if (fUseFastIndex && (nTime < GetAdjustedTime() - 12 * GetClockDrift(GetAdjustedTime())) && blockHash != 0)
 			return blockHash;
 			
         CBlock block;

--- a/src/version.h
+++ b/src/version.h
@@ -25,10 +25,11 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60006;
+static const int PROTOCOL_VERSION = 60007;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;
+static const int MIN_PROTO_VERSION_FORK = 60007;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this
@@ -37,6 +38,7 @@ static const int CADDR_TIME_VERSION = 31402;
 // only request blocks from nodes outside this range of versions
 static const int NOBLKS_VERSION_START = 60002;
 static const int NOBLKS_VERSION_END = 60004;
+static const int NOBLKS_VERSION_END_FORK = 60006;
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
@@ -44,8 +46,8 @@ static const int BIP0031_VERSION = 60000;
 // "mempool" command, enhanced "getdata" behavior starts with this version:
 static const int MEMPOOL_GD_VERSION = 60002;
 
-#define DISPLAY_VERSION_MAJOR       1
-#define DISPLAY_VERSION_MINOR       17
+#define DISPLAY_VERSION_MAJOR       2
+#define DISPLAY_VERSION_MINOR       0
 #define DISPLAY_VERSION_REVISION    0
 #define DISPLAY_VERSION_BUILD       0
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1501,7 +1501,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 				continue;
 		}
 
-        static int nMaxStakeSearchInterval = 60;
+        static int nMaxStakeSearchInterval = 15;
 		
 		// printf(">> block.GetBlockTime() = %"PRI64d", nStakeMinAge = %d, txNew.nTime = %d\n", block.GetBlockTime(), nStakeMinAge,txNew.nTime); 
         if (block.GetBlockTime() + nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)


### PR DESCRIPTION
Protocol requirements are raised to accept post-fork clients only after
the fork time Sat, 01 Aug 2015 16:00:00 GMT
Time Drift is changed to 30 seconds maximum, which is also the block
target. This is a strict enough drift allowance to reduce drift based
exploits, while still allowing some flexibility for nodes.

Maximum Stake Search Interval is changed to 15 seconds to give less
chances of producing hashed that will be rejected by the time drift
requirements.

Add another 10 confirmations to the network requirements for
transactions and coinstake transactions.