### PR TITLE
CheckSync was following a pointer chain to the last sync point 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2009,6 +2009,12 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 
 bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot) const
 {
+    if(bComputedCheckBlock) {
+        bComputedCheckBlock = true;
+        return bCheckBlockReturn;
+    }
+    bComputedCheckBlock = true;
+
     // These are checks that are independent of context
     // that can be verified before saving an orphan block.
 
@@ -2085,6 +2091,8 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot) const
     if (!CheckBlockSignature())
         return DoS(100, error("CheckBlock() : bad block signature"));
 
+
+    bCheckBlockReturn = true;
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -861,6 +861,10 @@ public:
     unsigned int nBits;
     unsigned int nNonce;
 
+    //Save hash once we calculate so we don't have to hash multiple times
+    mutable bool bComputedHash;
+    mutable uint256 hashThisBlock;
+
     CBlockHeader()
     {
         SetNull();
@@ -885,6 +889,9 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
+
+        bComputedHash = false;
+        hashThisBlock = 0;
     }
 
     bool IsNull() const
@@ -895,11 +902,20 @@ public:
     uint256 GetHash() const
     {
         uint256 thash;
-        void * scratchbuff = scrypt_buffer_alloc();
 
-        scrypt_hash(CVOIDBEGIN(nVersion), sizeof(block_header), UINTBEGIN(thash), scratchbuff);
+        if(bComputedHash) {
+            thash = hashThisBlock;
+        } else {
 
-        scrypt_buffer_free(scratchbuff);
+            void * scratchbuff = scrypt_buffer_alloc();
+
+            scrypt_hash(CVOIDBEGIN(nVersion), sizeof(block_header), UINTBEGIN(thash), scratchbuff);
+
+            scrypt_buffer_free(scratchbuff);
+
+            hashThisBlock = thash;
+            bComputedHash = true;
+        }
 
         return thash;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -945,6 +945,9 @@ public:
     mutable int nDoS;
     bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
 
+    // CheckBlock only compute once
+    mutable bool bComputedCheckBlock, bCheckBlockReturn;
+
     CBlock()
     {
         SetNull();
@@ -970,6 +973,8 @@ public:
         vchBlockSig.clear();
         vMerkleTree.clear();
         nDoS = 0;
+        bComputedCheckBlock = false;
+        bCheckBlockReturn = false;
     }
 
     // ppcoin: entropy bit for stake modifier if chosen by modifier


### PR DESCRIPTION
This sits on top of Pull request #25 and #26 

CheckSync was following a pointer chain to the last sync point with every new block so the further you got away from a checkpoint the longer it took. 
Changed so now when a block is traced back to a sync we save the hash, if the next blocks previous matches that hash we will already know that it can travel back to the sync.

Tested by looking at LoadExternalBlockFile and every 500 blocks printed (total elapsed time/ nloaded) in ms

nLoaded | Avg Before | Avg #25 | Avg #26 | Avg this
---|---|---|---|---
500 | 4.98ms | 2.54ms | 1.80ms | 1.77ms
20000 | 5.96ms | 3.38ms | 2.79ms | 2.59ms
100000 | 7.97ms | 5.26ms | 4.75ms | 3.76ms