### PR TITLE
2 Optimizations when verifying stake

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -253,7 +253,7 @@ static bool GetKernelStakeModifier(uint256 hashBlockFrom, uint64& nStakeModifier
     // loop to find the stake modifier later by a selection interval
     while (nStakeModifierTime < pindexFrom->GetBlockTime() + nStakeModifierSelectionInterval)
     {
-        if (!pindex->pnext)
+        if (!pindex->pnextWithStakeModifier)
         {   // reached best block; may happen if node is behind on block chain
             if (fPrintProofOfStake || (pindex->GetBlockTime() + nStakeMinAge - nStakeModifierSelectionInterval > GetAdjustedTime()))
                 return error("GetKernelStakeModifier() : reached best block %s at height %d from block %s",
@@ -265,7 +265,7 @@ static bool GetKernelStakeModifier(uint256 hashBlockFrom, uint64& nStakeModifier
                 return false;
 			}
         }
-        pindex = pindex->pnext;
+        pindex = pindex->pnextWithStakeModifier;
         if (pindex->GeneratedStakeModifier())
         {
             nStakeModifierHeight = pindex->nHeight;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1977,6 +1977,9 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 
     // Add to mapBlockIndex
     map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.insert(make_pair(hash, pindexNew)).first;
+    // Link pnextWithStakeModifier chains so we can skip around faster
+    pindexNew->linkPnextWithStakeModifier();
+
     if (pindexNew->IsProofOfStake())
         setStakeSeen.insert(make_pair(pindexNew->prevoutStake, pindexNew->nStakeTime));
     pindexNew->phashBlock = &((*mi).first);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2009,6 +2009,12 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 
 bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot) const
 {
+    if(bComputedCheckBlock) {
+        bComputedCheckBlock = true;
+        return bCheckBlockReturn;
+    }
+    bComputedCheckBlock = true;
+
     // These are checks that are independent of context
     // that can be verified before saving an orphan block.
 
@@ -2085,6 +2091,8 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot) const
     if (!CheckBlockSignature())
         return DoS(100, error("CheckBlock() : bad block signature"));
 
+
+    bCheckBlockReturn = true;
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -1397,9 +1397,12 @@ public:
     {
         if(GeneratedStakeModifier()){
             CBlockIndex* updatePrev = this->pprev;
-            while(updatePrev && !updatePrev->pnextWithStakeModifier) {
+            while(updatePrev && !updatePrev->GeneratedStakeModifier()) {
                 updatePrev->pnextWithStakeModifier = this;
                 updatePrev = updatePrev->pprev;
+            }
+            if(updatePrev) {
+                updatePrev->pnextWithStakeModifier = this; //make sure chain of nexts is complete
             }
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -1170,6 +1170,7 @@ public:
     const uint256* phashBlock;
     CBlockIndex* pprev;
     CBlockIndex* pnext;
+    CBlockIndex* pnextWithStakeModifier; //Allow for skipping to next block with stake modifier at a time for faster searching
     unsigned int nFile;
     unsigned int nBlockPos;
     uint256 nChainTrust; // ppcoin: trust score of block chain
@@ -1206,6 +1207,7 @@ public:
         phashBlock = NULL;
         pprev = NULL;
         pnext = NULL;
+        pnextWithStakeModifier = NULL;
         nFile = 0;
         nBlockPos = 0;
         nHeight = 0;
@@ -1231,6 +1233,7 @@ public:
         phashBlock = NULL;
         pprev = NULL;
         pnext = NULL;
+        pnextWithStakeModifier = NULL;
         nFile = nFileIn;
         nBlockPos = nBlockPosIn;
         nHeight = 0;
@@ -1387,6 +1390,18 @@ public:
     void print() const
     {
         printf("%s\n", ToString().c_str());
+    }
+
+    // Link pnextWithStakeModifier chains so we can skip around faster
+    void linkPnextWithStakeModifier()
+    {
+        if(GeneratedStakeModifier()){
+            CBlockIndex* updatePrev = this->pprev;
+            while(updatePrev && !updatePrev->pnextWithStakeModifier) {
+                updatePrev->pnextWithStakeModifier = this;
+                updatePrev = updatePrev->pprev;
+            }
+        }
     }
 };
 

--- a/src/main.h
+++ b/src/main.h
@@ -861,6 +861,10 @@ public:
     unsigned int nBits;
     unsigned int nNonce;
 
+    //Save hash once we calculate so we don't have to hash multiple times
+    mutable bool bComputedHash;
+    mutable uint256 hashThisBlock;
+
     CBlockHeader()
     {
         SetNull();
@@ -885,6 +889,9 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
+
+        bComputedHash = false;
+        hashThisBlock = 0;
     }
 
     bool IsNull() const
@@ -895,11 +902,20 @@ public:
     uint256 GetHash() const
     {
         uint256 thash;
-        void * scratchbuff = scrypt_buffer_alloc();
 
-        scrypt_hash(CVOIDBEGIN(nVersion), sizeof(block_header), UINTBEGIN(thash), scratchbuff);
+        if(bComputedHash) {
+            thash = hashThisBlock;
+        } else {
 
-        scrypt_buffer_free(scratchbuff);
+            void * scratchbuff = scrypt_buffer_alloc();
+
+            scrypt_hash(CVOIDBEGIN(nVersion), sizeof(block_header), UINTBEGIN(thash), scratchbuff);
+
+            scrypt_buffer_free(scratchbuff);
+
+            hashThisBlock = thash;
+            bComputedHash = true;
+        }
 
         return thash;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -945,6 +945,9 @@ public:
     mutable int nDoS;
     bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
 
+    // CheckBlock only compute once
+    mutable bool bComputedCheckBlock, bCheckBlockReturn;
+
     CBlock()
     {
         SetNull();
@@ -970,6 +973,8 @@ public:
         vchBlockSig.clear();
         vMerkleTree.clear();
         nDoS = 0;
+        bComputedCheckBlock = false;
+        bCheckBlockReturn = false;
     }
 
     // ppcoin: entropy bit for stake modifier if chosen by modifier

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -339,6 +339,9 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nBits          = diskindex.nBits;
         pindexNew->nNonce         = diskindex.nNonce;
 
+        // Link pnextWithStakeModifier chains so we can skip around faster
+        pindexNew->linkPnextWithStakeModifier();
+
         // Watch for genesis block
         if (pindexGenesisBlock == NULL && diskindex.GetBlockHash() == hashGenesisBlock)
             pindexGenesisBlock = pindexNew;


### PR DESCRIPTION
This sits on top of Pull request #25, #26 and #27  

- Cached hashes calculated when computing stake chains
- Allow jumping CBlockIndex directly to next stake modifier block. This is a potentially dangerous change, need to test what happens in the scenario of finding a new best chain and rewritting the chain. Remove commit if it is a problem. 5c7cafa

Tested by looking at LoadExternalBlockFile and every 500 blocks printed (total elapsed time/ nloaded) in ms
This change effects the rate of scaling and helps more on larger nLoaded

nLoaded | Avg Before | Avg #25 | Avg #26 | Avg #27 | Avg this
---|---|---|---|---|---
500 | 4.98ms | 2.54ms | 1.80ms | 1.77ms | 1.75ms
20000 | 5.96ms | 3.38ms | 2.79ms | 2.59ms | 2.45ms
100000 | 7.97ms | 5.26ms | 4.75ms | 3.76ms | 3.00ms
200000 | - | - | - | - | 3.23ms