### PR TITLE
Tweaks to the code to allow cross-compiling Windows executables

### DIFF
--- a/doc/windows-cross-compile.md
+++ b/doc/windows-cross-compile.md
@@ -1,0 +1,115 @@
+# Cross-Compiling the MintCoin wallet for Windows 
+
+This document explains how to build Windows binaries from a Linux
+system.
+
+# Starting system
+
+Have a Debian or Debian-derived system, like Ubuntu or Mint Linux.
+
+# Install MXE requirements
+
+http://mxe.cc/#requirements-debian
+
+```
+apt-get install \
+    autoconf \
+    automake \
+    autopoint \
+    bash \
+    bison \
+    bzip2 \
+    flex \
+    g++ \
+    g++-multilib \
+    gettext \
+    git \
+    gperf \
+    intltool \
+    libc6-dev-i386 \
+    libgdk-pixbuf2.0-dev \
+    libltdl-dev \
+    libssl-dev \
+    libtool-bin \
+    libxml-parser-perl \
+    make \
+    openssl \
+    p7zip-full \
+    patch \
+    perl \
+    pkg-config \
+    python \
+    ruby \
+    scons \
+    sed \
+    unzip \
+    wget \
+    xz-utils
+```
+
+# Get MXE
+
+Download from:
+
+http://mxe.cc/#download
+
+This "download" is actually just cloning a Git directory.
+
+# Build MXE
+
+Add `MXE_TARGETS` so that we get both 64-bit and 32-bit Windows binaries.
+
+```
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' cc
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' openssl
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' db
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' boost
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' miniupnpc
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' qt
+$ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' qttools
+```
+
+# Build Windows executables
+
+Add the path to MXE plus `usr/bin` to your `PATH`:
+
+`$ export PATH=$PATH:`_/your/mxe/path_`/usr/bin`
+
+To make a 32-bit Windows executable, go to the MintCoin repository
+and use the following:
+
+```
+$ cd src
+$ make -f makefile.linux-mingw TARGET_PLATFORM=i686
+```
+
+To make a 64-bit Windows executable, go to the MintCoin repository
+and use the following:
+
+$ make -f makefile.linux-mingw TARGET_PLATFORM=x86_64
+```
+
+Either will create a file called `mintcoind.exe`, which should be
+usable on a 32-bit or 64-bit Windows system, respectively.
+
+
+# Build Windows Qt executables
+
+To make a 32-bit Windows GUI executable, go to the MintCoin repository
+and use the following:
+
+```
+$ i686-w64-mingw32.static-qmake-qt5
+$ make
+```
+
+To make a 64-bit Windows GUI executable, go to the MintCoin repository
+and use the following:
+
+```
+$ x86_64-w64-mingw32.static-qmake-qt5
+$ make
+```
+
+Either will create a file called `release/MintCoin-Qt.exe`, which
+should be usable on a 32-bit or 64-bit Windows system, respectively.

--- a/mintcoin-qt.pro
+++ b/mintcoin-qt.pro
@@ -337,7 +337,7 @@ CODECFORTR = UTF-8
 TRANSLATIONS = $$files(src/qt/locale/bitcoin_*.ts)
 
 isEmpty(QMAKE_LRELEASE) {
-    win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
+    win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
     else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
 }
 isEmpty(QM_DIR):QM_DIR = $$PWD/src/qt/locale
@@ -356,11 +356,12 @@ OTHER_FILES += \
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {
     macx:BOOST_LIB_SUFFIX = -mt
-    windows:BOOST_LIB_SUFFIX = -mgw44-mt-s-1_50
+    windows:BOOST_LIB_SUFFIX = -mt
 }
 
 isEmpty(BOOST_THREAD_LIB_SUFFIX) {
     BOOST_THREAD_LIB_SUFFIX = $$BOOST_LIB_SUFFIX
+    windows:BOOST_THREAD_LIB_SUFFIX = _win32-mt
 }
 
 isEmpty(BDB_LIB_PATH) {
@@ -384,6 +385,7 @@ isEmpty(BOOST_INCLUDE_PATH) {
 }
 
 windows:DEFINES += WIN32
+windows:DEFINES += _WINDOWS
 windows:RC_FILE = src/qt/res/bitcoin-qt.rc
 
 windows:!contains(MINGW_THREAD_BUGFIX, 0) {
@@ -419,7 +421,7 @@ INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$
 LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
 LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
-windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
+windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32 -lpthread
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
 windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -25,12 +25,12 @@
 #include <ifaddrs.h>
 #endif
 
-typedef u_int SOCKET;
 #ifdef WIN32
 #define MSG_NOSIGNAL        0
 #define MSG_DONTWAIT        0
 typedef int socklen_t;
 #else
+typedef u_int SOCKET;
 #include "errno.h"
 #define WSAGetLastError()   errno
 #define WSAEINVAL           EINVAL

--- a/src/db.h
+++ b/src/db.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include <pthread.h>
 #include <db_cxx.h>
 
 class CAddress;

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -33,7 +33,8 @@ LIBS= \
  -l db_cxx \
  -l ssl \
  -l crypto \
- -l z
+ -l z \
+ -l pthread
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE -DCURL_STATICLIB -DMINIUPNP_STATICLIB
 DEBUGFLAGS=-g
@@ -57,6 +58,9 @@ ifneq (${USE_UPNP}, -)
 	DEFS += -DSTATICLIB -DMINIUPNP_STATICLIB -DUSE_UPNP=$(USE_UPNP)
 endif
 
+ifndef USE_IPV6
+    USE_IPV6 = 1
+endif
 ifneq (${USE_IPV6}, -)
 	DEFS += -DUSE_IPV6=$(USE_IPV6)
 endif

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -16,6 +16,7 @@
 #include <QScrollBar>
 
 #include <openssl/crypto.h>
+#include <pthread.h>
 #include <db_cxx.h>
 
 // TODO: add a scrollback limit, as there is currently none


### PR DESCRIPTION
In addition to a handful of changes needed to build for Windows, we also document how it is done.