### PR TITLE
Fix Qt warnings about stylesheet

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -197,12 +197,12 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     statusBar()->addPermanentWidget(frameBlocks);
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
-    qApp->setStyleSheet("background-color: #effbef;");
     //load stylesheet if present
     QFile File("style/stylesheet.qss");
-    File.open(QFile::ReadOnly);
-    QString StyleSheet = QLatin1String(File.readAll());
-    qApp->setStyleSheet(StyleSheet);
+    if (File.open(QFile::ReadOnly)) {
+        QString StyleSheet = QLatin1String(File.readAll());
+        qApp->setStyleSheet(StyleSheet);
+    }
 
     // Clicking on a transaction on the overview page simply sends you to transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), this, SLOT(gotoHistoryPage()));


### PR DESCRIPTION
This fixes Qt warnings on startup, which come from two sources:

1. The code tries to apply a style sheet for the application, but such style sheets need to be applied to components and not the whole application. Since it was just emitting an error message and not doing anything, this was removed.
2. The code _will_ successfully apply a style sheet if it is present in a specific file. However, it did not actually check if the file was there and just blindly tried to apply a non-existent file. We fix this by simply confirming that the open call succeeds.