### PR TITLE
Remove "defaultcodec" from translation files

### DIFF
--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.0" language="en">
-<defaultcodec>UTF-8</defaultcodec>
 <context>
     <name>AboutDialog</name>
     <message>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.0" language="ru">
-<defaultcodec>UTF-8</defaultcodec>
 <context>
     <name>AboutDialog</name>
     <message>


### PR DESCRIPTION
These "defaultcodec" values in the translation files are not used by Qt, which issues a warning about it. I see that the "defaultcodec" value is not used in Bitcoin these days, so it is clearly not necessary. Also, the translation defaults to LATIN-1, but MintCoin must be using a proper UTF-8 codec, otherwise the Russian translation would not work.