### PR TITLE
Add Windows cross-compile build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,24 +44,24 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    script: bash mxe-build.sh windows32
+    script: bash src/mxe-build.sh windows32
 
   # Build mintcoind
   # Cross-compile Windows 64-bit daemon
   - os: linux
     dist: trusty
     sudo: required
-    script: bash mxe-build.sh windows64
+    script: bash src/mxe-build.sh windows64
 
   - os: linux
     dist: trusty
     sudo: required
-    script: bash mxe-build.sh windows32-qt
+    script: bash src/mxe-build.sh windows32-qt
 
   - os: linux
     dist: trusty
     sudo: required
-    script: bash mxe-build.sh windows64-qt
+    script: bash src/mxe-build.sh windows64-qt
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
           - libqrencode-dev
           - libminiupnpc-dev
           - libminiupnpc8
-    script: cd src && make -f makefile.unix -j2
+    script: cd src && CFLAGS=-std=c++11 && make -f makefile.unix -j2
 
   # Build mintcoind
   # Cross-compile Windows 32-bit daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,14 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh
+    script: cd src && bash mxe-build.sh windows32
+
+  # Build mintcoind
+  # Cross-compile Windows 64-bit daemon
+  - os: linux
+    dist: trusty
+    sudo: required
+    script: cd src && bash mxe-build.sh windows64
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh windows32
+    script: cd src && bash mxe-build.sh windows32 && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/i686-w64-mingw32.static TARGET_PLATFORM=i686
 
   # Build mintcoind
   # Cross-compile Windows 64-bit daemon
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh windows64
+    script: cd src && bash mxe-build.sh windows64 && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/x86-64-w64-mingw32.static TARGET_PLATFORM=x86_64
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,16 @@ matrix:
     dist: trusty
     script: cd src && make -f makefile.unix -j2
 
+  # Build mintcoind
+  # Cross-compile Windows 32-bit daemon
+  - os: linux
+    script: src/mxe-build.sh
+
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
-  - os: linux
-    dist: trusty
-    script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
+  #- os: linux
+  #  dist: trusty
+  #  script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
   # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
@@ -45,57 +50,57 @@ matrix:
 
   # Build mintcoind
   # OS X 10.10 (Yosemite)
-  - os: osx
-    osx_image: xcode6.4
-    script: cd src && make -f makefile.osx -j2
+  #- os: osx
+  #  osx_image: xcode6.4
+  #  script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
   # OS X 10.10 (Yosemite)
-  - os: osx
-    osx_image: xcode6.4
-    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+  #- os: osx
+  #  osx_image: xcode6.4
+  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
   # OS X 10.11 (El Capitan)
-  - os: osx
-    osx_image: xcode7.3
-    script: cd src && make -f makefile.osx -j2
+  #- os: osx
+  #  osx_image: xcode7.3
+  #  script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
   # OS X 10.11 (El Capitan)
-  - os: osx
-    osx_image: xcode7.3
-    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+  #- os: osx
+  #  osx_image: xcode7.3
+  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
   # OS X 10.12 (Sierra)
-  - os: osx
-    osx_image: xcode8.3
-    script: cd src && make -f makefile.osx -j2
+  #- os: osx
+  #  osx_image: xcode8.3
+  #  script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
   # OS X 10.12 (Sierra)
-  - os: osx
-    osx_image: xcode8.3
-    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+  #- os: osx
+  #  osx_image: xcode8.3
+  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
   # OS X 10.13 (High Sierra)
-  - os: osx
-    osx_image: xcode9.3beta
-    script: cd src && make -f makefile.osx -j2
+  #- os: osx
+  #  osx_image: xcode9.3beta
+  #  script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
   # OS X 10.13 (High Sierra)
-  - os: osx
-    osx_image: xcode9.3beta
-    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+  #- os: osx
+  #  osx_image: xcode9.3beta
+  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build MintCoin-Qt
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
-  - os: linux
-    dist: trusty
-    script: qmake && make -j2
+  #- os: linux
+  #  dist: trusty
+  #  script: qmake && make -j2
 
   # Build MintCoin-Qt
   # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
@@ -116,18 +121,18 @@ matrix:
 
   # Build MintCoin-Qt
   # OS X 10.11 (El Capitan)
-  - os: osx
-    osx_image: xcode7.3
-    script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
+  #- os: osx
+  #  osx_image: xcode7.3
+  #  script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
 
   # Build MintCoin-Qt
   # OS X 10.12 (Sierra)
-  - os: osx
-    osx_image: xcode8.3
-    script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
+  #- os: osx
+  #  osx_image: xcode8.3
+  #  script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
 
   # Build MintCoin-Qt
   # OS X 10.13 (High Sierra)
-  - os: osx
-    osx_image: xcode9.3beta
-    script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
+  #- os: osx
+  #  osx_image: xcode9.3beta
+  #  script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ matrix:
           - libqrencode-dev
           - libminiupnpc-dev
           - libminiupnpc8
-    script: cd src && CFLAGS=-std=c++11 && make -f makefile.unix -j2
+    script: cd src && CXXFLAGS=-std=c++11 && make -f makefile.unix -j2
 
   # Build mintcoind
   # Cross-compile Windows 32-bit daemon
   - os: linux
     dist: trusty
     sudo: required
-    script: bash src/mxe-build.sh
+    script: cd src && bash mxe-build.sh
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,24 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh windows32 && PATH="$PATH:/usr/lib/mxe/usr/bin" && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/i686-w64-mingw32.static TARGET_PLATFORM=i686
+    script: bash mxe-build.sh windows32
 
   # Build mintcoind
   # Cross-compile Windows 64-bit daemon
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh windows64 && PATH="$PATH:/usr/lib/mxe/usr/bin" && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/x86-64-w64-mingw32.static TARGET_PLATFORM=x86_64
+    script: bash mxe-build.sh windows64
+
+  - os: linux
+    dist: trusty
+    sudo: required
+    script: bash mxe-build.sh windows32-qt
+
+  - os: linux
+    dist: trusty
+    sudo: required
+    script: bash mxe-build.sh windows64-qt
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,87 +53,128 @@ matrix:
     sudo: required
     script: bash src/mxe-build.sh windows64
 
+  # Build mintcoind static
+  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - libdb++-dev
+          - libboost-all-dev
+          - libqrencode-dev
+          - libminiupnpc-dev
+          - libminiupnpc8
+    script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
+
+  # Build mintcoind
+  # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
+  #- os: linux
+  #  dist: xenial
+  #  addons:
+  #    apt:
+  #      packages:
+  #        - libdb++-dev
+  #        - libboost-all-dev
+  #        - libqrencode-dev
+  #        - libminiupnpc-dev
+  #        - libminiupnpc8
+  #  script: cd src && make -f makefile.unix -j2
+
+  # Build mintcoind
+  # OS X 10.10 (Yosemite)
+  - os: osx
+    osx_image: xcode6.4
+    script: cd src && make -f makefile.osx -j2
+
+  # Build mintcoind static
+  # OS X 10.10 (Yosemite)
+  - os: osx
+    osx_image: xcode6.4
+    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+
+  # Build mintcoind
+  # OS X 10.11 (El Capitan)
+  - os: osx
+    osx_image: xcode7.3
+    script: cd src && make -f makefile.osx -j2
+
+  # Build mintcoind static
+  # OS X 10.11 (El Capitan)
+  - os: osx
+    osx_image: xcode7.3
+    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+
+  # Build mintcoind
+  # OS X 10.12 (Sierra)
+  - os: osx
+    osx_image: xcode8.3
+    script: cd src && make -f makefile.osx -j2
+
+  # Build mintcoind static
+  # OS X 10.12 (Sierra)
+  - os: osx
+    osx_image: xcode8.3
+    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+
+  # Build mintcoind
+  # OS X 10.13 (High Sierra)
+  - os: osx
+    osx_image: xcode9.3beta
+    script: cd src && make -f makefile.osx -j2
+
+  # Build mintcoind static
+  # OS X 10.13 (High Sierra)
+  - os: osx
+    osx_image: xcode9.3beta
+    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+
+  # Build MintCoin-Qt
+  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  - os: linux
+    dist: trusty
+    addons:
+      apt:
+        packages:
+          - libdb++-dev
+          - libboost-all-dev
+          - libqrencode-dev
+          - libminiupnpc-dev
+          - libminiupnpc8
+          - qt4-qmake
+          - libqt4-dev
+    script: qmake && make -j2
+
+  # Build MintCoin-Qt
+  # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
+  #- os: linux
+  #  dist: xenial
+  #  addons:
+  #    apt:
+  #      packages:
+  #        - libdb++-dev
+  #        - libboost-all-dev
+  #        - libqrencode-dev
+  #        - libminiupnpc-dev
+  #        - libminiupnpc8
+  #        - qt4-qmake
+  #        - libqt4-dev
+  #  script: qmake && make -j2
+
+  # Build MintCoin-Qt
+  # Cross-compile Windows 32-bit GUI
   - os: linux
     dist: trusty
     sudo: required
     script: bash src/mxe-build.sh windows32-qt
 
+  # Build MintCoin-Qt
+  # Cross-compile Windows 64-bit GUI
   - os: linux
     dist: trusty
     sudo: required
     script: bash src/mxe-build.sh windows64-qt
 
-  # Build mintcoind static
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
-  #- os: linux
-  #  dist: trusty
-  #  script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
-
-  # Build mintcoind
-  # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
-  #- os: linux
-  #  dist: xenial
-  #  script: cd src && make -f makefile.unix -j2
-
-  # Build mintcoind
-  # OS X 10.10 (Yosemite)
-  #- os: osx
-  #  osx_image: xcode6.4
-  #  script: cd src && make -f makefile.osx -j2
-
-  # Build mintcoind static
-  # OS X 10.10 (Yosemite)
-  #- os: osx
-  #  osx_image: xcode6.4
-  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
-
-  # Build mintcoind
-  # OS X 10.11 (El Capitan)
-  #- os: osx
-  #  osx_image: xcode7.3
-  #  script: cd src && make -f makefile.osx -j2
-
-  # Build mintcoind static
-  # OS X 10.11 (El Capitan)
-  #- os: osx
-  #  osx_image: xcode7.3
-  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
-
-  # Build mintcoind
-  # OS X 10.12 (Sierra)
-  #- os: osx
-  #  osx_image: xcode8.3
-  #  script: cd src && make -f makefile.osx -j2
-
-  # Build mintcoind static
-  # OS X 10.12 (Sierra)
-  #- os: osx
-  #  osx_image: xcode8.3
-  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
-
-  # Build mintcoind
-  # OS X 10.13 (High Sierra)
-  #- os: osx
-  #  osx_image: xcode9.3beta
-  #  script: cd src && make -f makefile.osx -j2
-
-  # Build mintcoind static
-  # OS X 10.13 (High Sierra)
-  #- os: osx
-  #  osx_image: xcode9.3beta
-  #  script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
-
-  # Build MintCoin-Qt
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
-  #- os: linux
-  #  dist: trusty
-  #  script: qmake && make -j2
-
-  # Build MintCoin-Qt
-  # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
-  #- os: linux
-  #  dist: xenial
-  #  script: qmake && make -j2
 
   # Build MintCoin-Qt
   # OS X 10.10 (Yosemite)
@@ -148,18 +189,18 @@ matrix:
 
   # Build MintCoin-Qt
   # OS X 10.11 (El Capitan)
-  #- os: osx
-  #  osx_image: xcode7.3
-  #  script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
+  - os: osx
+    osx_image: xcode7.3
+    script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
 
   # Build MintCoin-Qt
   # OS X 10.12 (Sierra)
-  #- os: osx
-  #  osx_image: xcode8.3
-  #  script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
+  - os: osx
+    osx_image: xcode8.3
+    script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
 
   # Build MintCoin-Qt
   # OS X 10.13 (High Sierra)
-  #- os: osx
-  #  osx_image: xcode9.3beta
-  #  script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2
+  - os: osx
+    osx_image: xcode9.3beta
+    script: brew install qrencode qt && ls /usr/local/opt/qt && /usr/local/opt/qt/bin/qmake && make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
   # Build mintcoind
   # Cross-compile Windows 32-bit daemon
   - os: linux
-    script: src/mxe-build.sh
+    script: bash src/mxe-build.sh
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: cpp
 sudo: false
 
-addons:
-  # Ubuntu packages
-  apt:
-    packages:
-      # These are required by the Linux build
-      - libdb++-dev
-      - libboost-all-dev
-      - libqrencode-dev
-      - libminiupnpc-dev
-      - libminiupnpc8
-      # These are required by the Linux Qt build
-      - qt4-qmake
-      - libqt4-dev
+#addons:
+#  # Ubuntu packages
+#  apt:
+#    packages:
+#      # These are required by the Linux build
+#      - libdb++-dev
+#      - libboost-all-dev
+#      - libqrencode-dev
+#      - libminiupnpc-dev
+#      - libminiupnpc8
+#      # These are required by the Linux Qt build
+#      - qt4-qmake
+#      - libqt4-dev
 
 install:
   # Travis already has OpenSSL and Boost installed via Homebrew, but we
@@ -29,11 +29,21 @@ matrix:
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   - os: linux
     dist: trusty
+    addons:
+      apt:
+        packages:
+          - libdb++-dev
+          - libboost-all-dev
+          - libqrencode-dev
+          - libminiupnpc-dev
+          - libminiupnpc8
     script: cd src && make -f makefile.unix -j2
 
   # Build mintcoind
   # Cross-compile Windows 32-bit daemon
   - os: linux
+    dist: trusty
+    sudo: required
     script: bash src/mxe-build.sh
 
   # Build mintcoind static

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh windows32 && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/i686-w64-mingw32.static TARGET_PLATFORM=i686
+    script: cd src && bash mxe-build.sh windows32 && PATH="$PATH:/usr/lib/mxe/usr/bin" && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/i686-w64-mingw32.static TARGET_PLATFORM=i686
 
   # Build mintcoind
   # Cross-compile Windows 64-bit daemon
   - os: linux
     dist: trusty
     sudo: required
-    script: cd src && bash mxe-build.sh windows64 && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/x86-64-w64-mingw32.static TARGET_PLATFORM=x86_64
+    script: cd src && bash mxe-build.sh windows64 && PATH="$PATH:/usr/lib/mxe/usr/bin" && make -f makefile.linux-mingw -j 2 DEPSDIR=/usr/lib/mxe/usr/x86-64-w64-mingw32.static TARGET_PLATFORM=x86_64
 
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
           - libqrencode-dev
           - libminiupnpc-dev
           - libminiupnpc8
-    script: cd src && CXXFLAGS=-std=c++11 && make -f makefile.unix -j2
+    script: cd src && make -f makefile.unix -j2
 
   # Build mintcoind
   # Cross-compile Windows 32-bit daemon

--- a/doc/windows-cross-compile.md
+++ b/doc/windows-cross-compile.md
@@ -3,11 +3,21 @@
 This document explains how to build Windows binaries from a Linux
 system.
 
+We use MXE to cross-compile. There are two basic approaches:
+
+1. Build the MXE itself from source
+2. Use MXE-provided packages
+
+Building from source is not really more difficult, but it does take
+longer and uses more CPU time.
+
 # Starting system
 
 Have a Debian or Debian-derived system, like Ubuntu or Mint Linux.
 
-# Install MXE requirements
+# Building from source
+
+## Install MXE requirements
 
 http://mxe.cc/#requirements-debian
 
@@ -47,7 +57,7 @@ apt-get install \
     xz-utils
 ```
 
-# Get MXE
+## Get MXE
 
 Download from:
 
@@ -55,7 +65,7 @@ http://mxe.cc/#download
 
 This "download" is actually just cloning a Git directory.
 
-# Build MXE
+## Build MXE
 
 Add `MXE_TARGETS` so that we get both 64-bit and 32-bit Windows binaries.
 
@@ -69,7 +79,7 @@ $ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' qt
 $ make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' qttools
 ```
 
-# Build Windows executables
+## Build Windows executables
 
 Add the path to MXE plus `usr/bin` to your `PATH`:
 
@@ -86,6 +96,8 @@ $ make -f makefile.linux-mingw TARGET_PLATFORM=i686
 To make a 64-bit Windows executable, go to the MintCoin repository
 and use the following:
 
+```
+$ cd src
 $ make -f makefile.linux-mingw TARGET_PLATFORM=x86_64
 ```
 
@@ -93,7 +105,90 @@ Either will create a file called `mintcoind.exe`, which should be
 usable on a 32-bit or 64-bit Windows system, respectively.
 
 
-# Build Windows Qt executables
+## Build Windows Qt executables
+
+To make a 32-bit Windows GUI executable, go to the MintCoin repository
+and use the following:
+
+```
+$ i686-w64-mingw32.static-qmake-qt5
+$ make
+```
+
+To make a 64-bit Windows GUI executable, go to the MintCoin repository
+and use the following:
+
+```
+$ x86_64-w64-mingw32.static-qmake-qt5
+$ make
+```
+
+Either will create a file called `release/MintCoin-Qt.exe`, which
+should be usable on a 32-bit or 64-bit Windows system, respectively.
+
+# Building from package
+
+## Add the MXE package repository
+
+```
+$ sudo apt-get update
+$ echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
+$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+$ sudo apt-get update
+```
+
+## Install the MXE packages for the build
+
+For a 32-bit build:
+
+```
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-cc
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-openssl
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-db
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-boost
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-miniupnpc
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-qt5
+sudo apt-get --yes install mxe-i686-w64-mingw32.static-qttools
+```
+
+For a 64-bit build:
+
+```
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-cc
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-openssl
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-db
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-boost
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-miniupnpc
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-qt5
+sudo apt-get --yes install mxe-x86-64-w64-mingw32.static-qttools
+```
+
+## Build Windows executables
+
+Add the path to MXE:
+
+`$ export PATH=$PATH:`/usr/lib/mxe/mxe/usr/bin`
+
+To make a 32-bit Windows executable, go to the MintCoin repository
+and use the following:
+
+```
+$ cd src
+$ make -f makefile.linux-mingw DEPSDIR=/usr/lib/mxe/usr/686-w64-mingw32.static  TARGET_PLATFORM=i686
+```
+
+To make a 64-bit Windows executable, go to the MintCoin repository
+and use the following:
+
+```
+$ cd src
+$ make -f makefile.linux-mingw DEPSDIR=/usr/lib/mxe/usr/686-w64-mingw32.static  TARGET_PLATFORM=i686
+```
+
+Either will create a file called `mintcoind.exe`, which should be
+usable on a 32-bit or 64-bit Windows system, respectively.
+
+## Build Windows Qt executables
 
 To make a 32-bit Windows GUI executable, go to the MintCoin repository
 and use the following:

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -2,7 +2,7 @@
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-DEPSDIR:=/mnt/mxe/usr/$(TARGET_PLATFORM)-w64-mingw32.static
+DEPSDIR ?= /mnt/mxe/usr/$(TARGET_PLATFORM)-w64-mingw32.static
 HOST:=$(TARGET_PLATFORM)-w64-mingw32
 INCDIR:=$(DEPSDIR)/include
 LIBDIR:=$(DEPSDIR)/lib

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -19,4 +19,5 @@ sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
 
 MXEDIR=/usr/lib/mxe
 export PATH=$PATH:$MXEDIR/usr/bin
-make -f makefile.linux-mingw DEPSDIR=$MXEDIR/usr/$MXE_TARGET
+make -f makefile.linux-mingw \
+    DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=i686

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -4,7 +4,7 @@ if [ $1 == "windows32" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
     CPU_TARGET="i686"
 else
-    MXE_TARGET="x86_64-w64-mingw32.static"
+    MXE_TARGET="x86-64-w64-mingw32.static"
     CPU_TARGET="x86_64"
 fi
 

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+MXE_TARGET="i686-w64-mingw32.static"
+
+sudo apt-get update
+
+echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" \
+    | sudo tee /etc/apt/sources.list.d/mxeapt.list
+sudo apt-key adv --keyserver keyserver.ubuntu.com \
+    --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+
+sudo apt-get update
+
+sudo apt-get --yes install mxe-${MXE_TARGET}-cc
+sudo apt-get --yes install mxe-${MXE_TARGET}-openssl
+sudo apt-get --yes install mxe-${MXE_TARGET}-db
+sudo apt-get --yes install mxe-${MXE_TARGET}-boost
+sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -1,6 +1,12 @@
 #! /bin/bash
 
-MXE_TARGET="i686-w64-mingw32.static"
+if [ $1 == "windows32" ]; then
+    MXE_TARGET="i686-w64-mingw32.static"
+    CPU_TARGET="i686"
+else
+    MXE_TARGET="x86_64-w64-mingw32.static"
+    CPU_TARGET="x86_64"
+fi
 
 sudo apt-get update
 
@@ -17,7 +23,9 @@ sudo apt-get --yes install mxe-${MXE_TARGET}-db
 sudo apt-get --yes install mxe-${MXE_TARGET}-boost
 sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
 
+NCPU=`cat /proc/cpuinfo | grep -c ^processor`
+
 MXEDIR=/usr/lib/mxe
 export PATH=$PATH:$MXEDIR/usr/bin
-make -f makefile.linux-mingw \
-    DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=i686
+make -f makefile.linux-mingw -j $NCPU \
+    DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -16,3 +16,7 @@ sudo apt-get --yes install mxe-${MXE_TARGET}-openssl
 sudo apt-get --yes install mxe-${MXE_TARGET}-db
 sudo apt-get --yes install mxe-${MXE_TARGET}-boost
 sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
+
+MXEDIR=/usr/lib/mxe
+export PATH=$PATH:$MXEDIR/usr/bin
+make -f makefile.linux-mingw DEPSDIR=$MXEDIR/usr/$MXE_TARGET

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -40,9 +40,10 @@ sudo apt-get --yes install mxe-${MXE_TARGET}-db
 sudo apt-get --yes install mxe-${MXE_TARGET}-boost
 sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
 
+export PATH=$PATH:$MXEDIR/usr/bin
+
 if [ $QT_BUILD == "no" ]; then
     cd src
-    export PATH=$PATH:$MXEDIR/usr/bin
     make -f makefile.linux-mingw -j $NCPU \
         DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET
 else

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -2,11 +2,25 @@
 
 if [ $1 == "windows32" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
-#    CPU_TARGET="i686"
-else
+    CPU_TARGET="i686"
+    QT_BUILD="no"
+elif [ $1 == "windows64" ]; then
     MXE_TARGET="x86-64-w64-mingw32.static"
-#    CPU_TARGET="x86_64"
+    CPU_TARGET="x86_64"
+    QT_BUILD="no"
+elif [ $1 == "windows32-qt" ]; then
+    MXE_TARGET="i686-w64-mingw32.static"
+    CPU_TARGET="i686"
+    QT_BUILD="yes"
+elif [ $2 == "windows64-qt" ]; then
+    MXE_TARGET="x86-64-w64-mingw32.static"
+    CPU_TARGET="x86_64"
+    QT_BUILD="yes"
 fi
+
+MXEDIR=/usr/lib/mxe
+
+NCPU=`cat /proc/cpuinfo | grep -c ^processor`
 
 sudo apt-get update
 
@@ -23,9 +37,15 @@ sudo apt-get --yes install mxe-${MXE_TARGET}-db
 sudo apt-get --yes install mxe-${MXE_TARGET}-boost
 sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
 
-#NCPU=`cat /proc/cpuinfo | grep -c ^processor`
-#
-#MXEDIR=/usr/lib/mxe
-#export PATH=$PATH:$MXEDIR/usr/bin
-#make -f makefile.linux-mingw -j $NCPU \
-#    DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET
+if [ $QT_BUILD == "no" ]; then
+    cd src
+    export PATH=$PATH:$MXEDIR/usr/bin
+    make -f makefile.linux-mingw -j $NCPU \
+        DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET
+else
+    $MXEDIR/usr/bin/$CPU_TARGET-w64-mingw32.static-qmake-qt5
+    sudo apt-get --yes install mxe-${MXE_TARGET}-qt
+    sudo apt-get --yes install mxe-${MXE_TARGET}-qttools
+    qmake
+    make -j $NCPU
+fi

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+# Set our MXE and CPU information based on what type of
+# wallet we want, and for which type of Windows.
 if [ $1 == "windows32" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
     CPU_TARGET="i686"
@@ -21,10 +23,7 @@ else
     exit 1
 fi
 
-MXEDIR=/usr/lib/mxe
-
-NCPU=`cat /proc/cpuinfo | grep -c ^processor`
-
+# Add the MXE package repository.
 sudo apt-get update
 
 echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" \
@@ -34,14 +33,21 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com \
 
 sudo apt-get update
 
+# Add the required MXE build packages and libraries.
 sudo apt-get --yes install mxe-${MXE_TARGET}-cc
 sudo apt-get --yes install mxe-${MXE_TARGET}-openssl
 sudo apt-get --yes install mxe-${MXE_TARGET}-db
 sudo apt-get --yes install mxe-${MXE_TARGET}-boost
 sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
 
+# Parallel build, based on our number of CPUs available.
+NCPU=`cat /proc/cpuinfo | grep -c ^processor`
+
+# Some variables used by both Qt and daemon builds.
+MXEDIR=/usr/lib/mxe
 export PATH=$PATH:$MXEDIR/usr/bin
 
+# Invoke the magical commands to get MintCoin built.
 if [ $QT_BUILD == "no" ]; then
     cd src
     make -f makefile.linux-mingw -j $NCPU \

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -47,9 +47,8 @@ if [ $QT_BUILD == "no" ]; then
     make -f makefile.linux-mingw -j $NCPU \
         DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET
 else
-    $MXEDIR/usr/bin/$CPU_TARGET-w64-mingw32.static-qmake-qt5
-    sudo apt-get --yes install mxe-${MXE_TARGET}-qt
+    sudo apt-get --yes install mxe-${MXE_TARGET}-qt5
     sudo apt-get --yes install mxe-${MXE_TARGET}-qttools
-    qmake
+    $MXEDIR/usr/bin/$CPU_TARGET-w64-mingw32.static-qmake-qt5
     make -j $NCPU
 fi

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -2,10 +2,10 @@
 
 if [ $1 == "windows32" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
-    CPU_TARGET="i686"
+#    CPU_TARGET="i686"
 else
     MXE_TARGET="x86-64-w64-mingw32.static"
-    CPU_TARGET="x86_64"
+#    CPU_TARGET="x86_64"
 fi
 
 sudo apt-get update
@@ -23,9 +23,9 @@ sudo apt-get --yes install mxe-${MXE_TARGET}-db
 sudo apt-get --yes install mxe-${MXE_TARGET}-boost
 sudo apt-get --yes install mxe-${MXE_TARGET}-miniupnpc
 
-NCPU=`cat /proc/cpuinfo | grep -c ^processor`
-
-MXEDIR=/usr/lib/mxe
-export PATH=$PATH:$MXEDIR/usr/bin
-make -f makefile.linux-mingw -j $NCPU \
-    DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET
+#NCPU=`cat /proc/cpuinfo | grep -c ^processor`
+#
+#MXEDIR=/usr/lib/mxe
+#export PATH=$PATH:$MXEDIR/usr/bin
+#make -f makefile.linux-mingw -j $NCPU \
+#    DEPSDIR=$MXEDIR/usr/$MXE_TARGET TARGET_PLATFORM=$CPU_TARGET

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -55,6 +55,6 @@ if [ $QT_BUILD == "no" ]; then
 else
     sudo apt-get --yes install mxe-${MXE_TARGET}-qt5
     sudo apt-get --yes install mxe-${MXE_TARGET}-qttools
-    $MXEDIR/usr/bin/$CPU_TARGET-w64-mingw32.static-qmake-qt5
+    $CPU_TARGET-w64-mingw32.static-qmake-qt5
     make -j $NCPU
 fi

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -12,10 +12,13 @@ elif [ $1 == "windows32-qt" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
     CPU_TARGET="i686"
     QT_BUILD="yes"
-elif [ $2 == "windows64-qt" ]; then
+elif [ $1 == "windows64-qt" ]; then
     MXE_TARGET="x86-64-w64-mingw32.static"
     CPU_TARGET="x86_64"
     QT_BUILD="yes"
+else
+    echo "Syntax: $0 [ windows32 | windows64 | windows32-qt | windows64-qt ]">&2
+    exit 1
 fi
 
 MXEDIR=/usr/lib/mxe

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include "serialize.h"
 #include "compat.h"
+#include "serialize.h"
 
 extern int nConnectTimeout;
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -7,8 +7,12 @@
 #include <string>
 #include <vector>
 
-#include "compat.h"
+#ifdef WIN32
+#include <winsock2.h>
+#endif
+
 #include "serialize.h"
+#include "compat.h"
 
 extern int nConnectTimeout;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1388,7 +1388,7 @@ bool CWallet::CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& w
     return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, coinControl);
 }
 
-bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64& nMinWeight, uint64& nMaxWeight, uint64& nWeight, uint& nSecondsUntilNextMint)
+bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64& nMinWeight, uint64& nMaxWeight, uint64& nWeight, unsigned int& nSecondsUntilNextMint)
 {
     // Choose coins to use
     int64 nBalance = GetBalance();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1453,7 +1453,7 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64& nMinWeight, uint
 
     // Figure out age of oldest coin (this is a bit tricky because if time
     // changes then the time of the oldest coin may be in the future)
-    uint nAgeOfOldestCoin;
+    unsigned int nAgeOfOldestCoin;
     int64 now = GetTime();
     if (now >= nTimeOfOldestCoin) {
         nAgeOfOldestCoin = now - nTimeOfOldestCoin;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -179,7 +179,7 @@ public:
     bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const CCoinControl *coinControl=NULL);
     bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const CCoinControl *coinControl=NULL);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
-    bool GetStakeWeight(const CKeyStore& keystore, uint64& nMinWeight, uint64& nMaxWeight, uint64& nWeight, uint& nSecondsUntilNextMint);
+    bool GetStakeWeight(const CKeyStore& keystore, uint64& nMinWeight, uint64& nMaxWeight, uint64& nWeight, unsigned int& nSecondsUntilNextMint);
     bool CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int64 nSearchInterval, CTransaction& txNew);
     std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);
     std::string SendMoneyToDestination(const CTxDestination &address, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);


### PR DESCRIPTION
We can now build Windows executables using Travis CI, by installing MXE packages from the package repository. We also document this method in the Windows build instructions.