### PR TITLE
Change from weird date formats to ISO 8601 format

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -465,7 +465,7 @@ bool AppInit2()
     printf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
     printf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
     if (!fLogTimestamps)
-        printf("Startup time: %s\n", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
+        printf("Startup time: %s\n", DateTimeStrFormat(GetTime()).c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
     printf("Used data directory %s\n", strDataDir.c_str());
     std::ostringstream strErrors;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1171,11 +1171,10 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
 
     printf("InvalidChainFound: invalid block=%s  height=%d  trust=%s  date=%s\n",
       pindexNew->GetBlockHash().ToString().substr(0,20).c_str(), pindexNew->nHeight,
-      pindexNew->nChainTrust.ToString().c_str(), DateTimeStrFormat("%x %H:%M:%S",
-      pindexNew->GetBlockTime()).c_str());
+      pindexNew->nChainTrust.ToString().c_str(), DateTimeStrFormat(pindexNew->GetBlockTime()).c_str());
     printf("InvalidChainFound:  current best=%s  height=%d  trust=%s  date=%s\n",
       hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, nBestChainTrust.ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      DateTimeStrFormat(pindexBest->GetBlockTime()).c_str());
 }
 
 void CBlockHeader::UpdateTime(const CBlockIndex* pindexPrev)
@@ -1863,7 +1862,7 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
     nTransactionsUpdated++;
     printf("SetBestChain: new best=%s  height=%d  trust=%s  date=%s\n",
       hashBestChain.ToString().c_str(), nBestHeight, nBestChainTrust.ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      DateTimeStrFormat(pindexBest->GetBlockTime()).c_str());
 
 	printf("Stake checkpoint: %x\n", pindexBest->nStakeModifierChecksum);
 
@@ -2704,7 +2703,7 @@ void PrintBlockTree()
             pindex->nBlockPos,
             block.GetHash().ToString().c_str(),
             block.nBits,
-            DateTimeStrFormat("%x %H:%M:%S", block.GetBlockTime()).c_str(),
+            DateTimeStrFormat(block.GetBlockTime()).c_str(),
             FormatMoney(pindex->nMint).c_str(),
             block.vtx.size());
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -197,13 +197,8 @@ Value listunspent(const Array& params, bool fHelp)
         entry.push_back(Pair("scriptPubKey", HexStr(pk.begin(), pk.end())));
         entry.push_back(Pair("amount",ValueFromAmount(nValue)));
         entry.push_back(Pair("confirmations",out.nDepth));
-        char cTimeBuf[sizeof("YYYY-mm-ddTHH:MM:SSZ")];
-        time_t tTxTime = time_t(out.tx->nTime);
-        strftime(cTimeBuf, sizeof(cTimeBuf), "%Y-%m-%dT%H:%M:%SZ", gmtime(&tTxTime));
-        entry.push_back(Pair("txtime", string(cTimeBuf)));
-        time_t tTxTimeReceived = time_t(out.tx->nTimeReceived);
-        strftime(cTimeBuf, sizeof(cTimeBuf), "%Y-%m-%dT%H:%M:%SZ", gmtime(&tTxTimeReceived));
-        entry.push_back(Pair("txtimereceived", string(cTimeBuf)));
+        entry.push_back(Pair("txtime", DateTimeStrFormat(out.tx->nTime)));
+        entry.push_back(Pair("txtimereceived", DateTimeStrFormat(out.tx->nTimeReceived)));
         results.push_back(entry);
     }
 

--- a/src/txdb-bdb.cpp
+++ b/src/txdb-bdb.cpp
@@ -200,7 +200,7 @@ bool CTxDB::LoadBlockIndex()
     nBestChainTrust = pindexBest->nChainTrust;
     printf("LoadBlockIndex(): hashBestChain=%s  height=%d  trust=%s  date=%s\n",
       hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, CBigNum(nBestChainTrust).ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      DateTimeStrFormat(pindexBest->GetBlockTime()).c_str());
 
     // ppcoin: load hashSyncCheckpoint
     if (!ReadSyncCheckpoint(Checkpoints::hashSyncCheckpoint))

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -393,7 +393,7 @@ bool CTxDB::LoadBlockIndex()
 
     printf("LoadBlockIndex(): hashBestChain=%s  height=%d  trust=%s  date=%s\n",
       hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, CBigNum(nBestChainTrust).ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      DateTimeStrFormat(pindexBest->GetBlockTime()).c_str());
 
     // NovaCoin: load hashSyncCheckpoint
     if (!ReadSyncCheckpoint(Checkpoints::hashSyncCheckpoint))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -243,7 +243,7 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
 
             // Debug print useful for profiling
             if (fLogTimestamps && fStartedNewLine)
-                fprintf(fileout, "%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
+                fprintf(fileout, "%s ", DateTimeStrFormat(GetTime()).c_str());
             if (pszFormat[strlen(pszFormat) - 1] == '\n')
                 fStartedNewLine = true;
             else

--- a/src/util.h
+++ b/src/util.h
@@ -356,10 +356,10 @@ inline std::string DateTimeStrFormat(const char* pszFormat, int64 nTime)
     return pszTime;
 }
 
-static const std::string strTimestampFormat = "%Y-%m-%d %H:%M:%S UTC";
+static const char *strTimestampFormat = "%Y-%m-%dT%H:%M:%SZ";
 inline std::string DateTimeStrFormat(int64 nTime)
 {
-    return DateTimeStrFormat(strTimestampFormat.c_str(), nTime);
+    return DateTimeStrFormat(strTimestampFormat, nTime);
 }
 
 


### PR DESCRIPTION
There were a lot of places in the code which had a strange, composite date format: 
```
"%x %H:%M:%S"
```
This used the localized version of the date, but then always 24-hour time. Really, we should always either use [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) **_or_** a fully-localized version (including the time).

Since the main usage is for debugging, we change everything to ISO 8601. This prevents confusion when comparing logs between systems and users with different local date formats.

Note that we are able to simplify the recently-added timestamp information presented in the `listunspent` RPC call. I did not know about the `DateTimeStrFormat()` function when that was written, and using it simplifies the code.