### PR TITLE
Set the "large-address-aware" flag when building Windows 32-bit Qt version

### DIFF
--- a/mintcoin-qt.pro
+++ b/mintcoin-qt.pro
@@ -37,10 +37,6 @@ QMAKE_LFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
 # for extra security on Windows: enable ASLR and DEP via GCC linker flags
 win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
 
-# Also support IMAGE_FILE_LARGE_ADDRESS_AWARE on Windows, which increases
-# the amount of memory a 32-bit application can access.
-#win32:QMAKE_LFLAGS *= -Wl,--large-address-aware
-
 # use: qmake "USE_QRCODE=1"
 # libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support
 contains(USE_QRCODE, 1) {

--- a/mintcoin-qt.pro
+++ b/mintcoin-qt.pro
@@ -37,6 +37,10 @@ QMAKE_LFLAGS *= -fstack-protector-all --param ssp-buffer-size=1
 # for extra security on Windows: enable ASLR and DEP via GCC linker flags
 win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
 
+# Also support IMAGE_FILE_LARGE_ADDRESS_AWARE on Windows, which increases
+# the amount of memory a 32-bit application can access.
+win32:QMAKE_LFLAGS *= -Wl,--large-address-aware
+
 # use: qmake "USE_QRCODE=1"
 # libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support
 contains(USE_QRCODE, 1) {

--- a/mintcoin-qt.pro
+++ b/mintcoin-qt.pro
@@ -39,7 +39,7 @@ win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
 
 # Also support IMAGE_FILE_LARGE_ADDRESS_AWARE on Windows, which increases
 # the amount of memory a 32-bit application can access.
-win32:QMAKE_LFLAGS *= -Wl,--large-address-aware
+#win32:QMAKE_LFLAGS *= -Wl,--large-address-aware
 
 # use: qmake "USE_QRCODE=1"
 # libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -14,6 +14,7 @@ elif [ $1 == "windows32-qt" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
     CPU_TARGET="i686"
     QT_BUILD="yes"
+    export LFLAGS="-Wl,--large-address-aware"
 elif [ $1 == "windows64-qt" ]; then
     MXE_TARGET="x86-64-w64-mingw32.static"
     CPU_TARGET="x86_64"

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -14,7 +14,7 @@ elif [ $1 == "windows32-qt" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
     CPU_TARGET="i686"
     QT_BUILD="yes"
-    export LFLAGS="-Wl,--large-address-aware"
+    export LDFLAGS="-Wl,--large-address-aware"
 elif [ $1 == "windows64-qt" ]; then
     MXE_TARGET="x86-64-w64-mingw32.static"
     CPU_TARGET="x86_64"

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -14,11 +14,12 @@ elif [ $1 == "windows32-qt" ]; then
     MXE_TARGET="i686-w64-mingw32.static"
     CPU_TARGET="i686"
     QT_BUILD="yes"
-    export LDFLAGS="-Wl,--large-address-aware"
+    OUR_QMAKE_EXTRA='QMAKE_LFLAGS+="-Wl,--large-address-aware"'
 elif [ $1 == "windows64-qt" ]; then
     MXE_TARGET="x86-64-w64-mingw32.static"
     CPU_TARGET="x86_64"
     QT_BUILD="yes"
+    OUR_QMAKE_EXTRA=''
 else
     echo "Syntax: $0 [ windows32 | windows64 | windows32-qt | windows64-qt ]">&2
     exit 1
@@ -56,6 +57,6 @@ if [ $QT_BUILD == "no" ]; then
 else
     sudo apt-get --yes install mxe-${MXE_TARGET}-qt5
     sudo apt-get --yes install mxe-${MXE_TARGET}-qttools
-    $CPU_TARGET-w64-mingw32.static-qmake-qt5
+    $CPU_TARGET-w64-mingw32.static-qmake-qt5 $OUR_QMAKE_EXTRA
     make -j $NCPU
 fi


### PR DESCRIPTION
It seems that we were running up into the default 2 GB process size limit for 32-bit applications in Windows. 32-bit applications running in 32-bit Windows can support up to 3 GB of RAM, and 32-bit applications running in 64-bit Windows can support up too 4 GB of RAM, but they need to be compiled with this feature enabled.

Here's the Microsoft page about this build option, IMAGE_FILE_LARGE_ADDRESS_AWARE, for your reading pleasure:

https://docs.microsoft.com/en-gb/windows/desktop/Memory/memory-limits-for-windows-releases#memory_limits

In our case we are using the MXE cross-compile from Linux, and need to add the -Wl,--large-address-aware flag to our 32-bit Windows build.