### PR TITLE
Fix warnings from recent gcc versions

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -40,7 +40,9 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
     switch(vDataToHash.size() & 3)
     {
     case 3: k1 ^= tail[2] << 16;
+            // fall thru
     case 2: k1 ^= tail[1] << 8;
+            // fall thru
     case 1: k1 ^= tail[0];
             k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4235,7 +4235,9 @@ void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash
         unsigned char pchPadding1[64];
     }
     tmp;
-    memset(&tmp, 0, sizeof(tmp));
+    // We cast our structure to void* for this memset() to silence
+    // warnings from gcc.
+    memset((void *)&tmp, 0, sizeof(tmp));
 
     tmp.block.nVersion       = pblock->nVersion;
     tmp.block.hashPrevBlock  = pblock->hashPrevBlock;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -30,7 +30,13 @@ CMessageHeader::CMessageHeader()
 CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, ::pchMessageStart, sizeof(pchMessageStart));
-    strncpy(pchCommand, pszCommand, COMMAND_SIZE);
+    int i;
+    for (i=0; (i < COMMAND_SIZE) && (pszCommand[i] != '\0'); i++) {
+        pchCommand[i] = pszCommand[i];
+    }
+    while (i < COMMAND_SIZE) {
+        pchCommand[i++] = '\0';
+    }
     nMessageSize = nMessageSizeIn;
     nChecksum = 0;
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -288,6 +288,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             sRecurringSendEntries = value.toString();
             settings.setValue("sRecurringSendEntries", sRecurringSendEntries);
             }
+            break;
         case PasswordOnSend:
             bPasswordOnSend = value.toBool();
             settings.setValue("bPasswordOnSend",bPasswordOnSend);


### PR DESCRIPTION
I noticed a few warnings have appeared in the build as my gcc has upgraded to a newer version. This PR fixes them.

Two of these (`strncpy()` and the missing `break`) may potentially be actual bugs. 