### PR TITLE
Remove terrible addresses from address manager

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -498,6 +498,12 @@ public:
             Check();
         }
     }
+
+    // Remove any terrible addresses from our manager.
+    unsigned int CleanTerribleAddresses(void);
+
+private:
+    unsigned int CleanTerribleAddressesInBucket(std::set<int> &vNew);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3185,6 +3185,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                 vAddrOk.push_back(addr);
         }
         addrman.Add(vAddrOk, pfrom->addr, 2 * 60 * 60);
+        addrman.CleanTerribleAddresses();
         if (vAddr.size() < 1000)
             pfrom->fGetAddr = false;
         if (pfrom->fOneShot)


### PR DESCRIPTION
This pull request (PR) addresses issue #105, which is the wallet not cleaning out old addresses.

The only code which ever removed anything from the address manager was called if one of the buckets was full. (The address manager divides the addresses up into "buckets" for some reason, with a maximum number of addresses per bucket.) It would only ever delete a single address in this case.

Luckily, there was already code which would define a given address as "terrible", which was re-used in this PR.

It does two main things:

1. When a bucket is full, the code now removes _all_ of the "terrible" addresses in that bucket, instead of just one. While this will not prevent bad addresses from accumulating, it should over time get rid of most of them.

2. More importantly, when the wallet receives addresses from a peer, it adds them all into the address manager as before, but now when that is done it goes through all of the "terrible" addresses that the address manager knows about and gets rid of them. Any node connected to peers that provide addresses will quickly get rid of the "terrible" addresses.

On my wallet, I went from having 17000 or so addresses to 650 or so, without any obvious other side-effects. The wallet is currently connected to 56 peers and appears to be functioning normally.

As usual, no tests were added for any of this because we don't have a test suite in MintCoin. 😬