### PR TITLE
Windows build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 matrix:
   include:
   # Build mintcoind
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  # Ubuntu 16.04 LTS (Xenial Xerus) is our latest Ubuntu version
   - os: linux
     dist: xenial
     sudo: required
@@ -22,7 +22,6 @@ matrix:
           - libboost-all-dev
           - libqrencode-dev
           - libminiupnpc-dev
-          - libminiupnpc8
     script: cd src && make -f makefile.unix -j2
 
   # Build mintcoind
@@ -40,7 +39,7 @@ matrix:
     script: bash src/mxe-build.sh windows64
 
   # Build mintcoind
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  # Ubuntu 16.04 LTS (Xenial Xerus) is our latest Ubuntu version
   # Make a 32-bit version using Debian multiarch
   - os: linux
     dist: xenial
@@ -87,7 +86,7 @@ matrix:
     script: cd src && make -f makefile.unix -j2
 
   # Build mintcoind static
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  # Ubuntu 16.04 LTS (Xenial Xerus) is our latest Ubuntu version
   - os: linux
     dist: xenial
     sudo: required
@@ -98,11 +97,10 @@ matrix:
           - libboost-all-dev
           - libqrencode-dev
           - libminiupnpc-dev
-          - libminiupnpc8
     script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind static
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  # Ubuntu 16.04 LTS (Xenial Xerus) is our latest Ubuntu version
   # Make a 32-bit version using Debian multiarch
   - os: linux
     dist: xenial
@@ -149,31 +147,6 @@ matrix:
     script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
-  # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
-  #- os: linux
-  #  dist: xenial
-  #  sudo: required
-  #  addons:
-  #    apt:
-  #      packages:
-  #        - libdb++-dev
-  #        - libboost-all-dev
-  #        - libqrencode-dev
-  #        - libminiupnpc-dev
-  #        - libminiupnpc8
-  #  script: cd src && make -f makefile.unix -j2 && python mega-copy.py mintcoind $TRAVIS_BRANCH/mintcoind.linux-ubuntu-xenial
-
-  # Build mintcoind
-  # OS X 10.10 (Yosemite)
-  #
-  # "pip: command not found" on Travis, so we will just not build this
-
-  # Build mintcoind static
-  # OS X 10.10 (Yosemite)
-  #
-  # "pip: command not found" on Travis, so we will just not build this
-
-  # Build mintcoind
   # OS X 10.11 (El Capitan)
   - os: osx
     osx_image: xcode7.3
@@ -210,7 +183,7 @@ matrix:
     script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build MintCoin-Qt
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  # Ubuntu 16.04 LTS (Xenial Xerus) is our latest Ubuntu version
   - os: linux
     dist: xenial
     sudo: required
@@ -221,13 +194,12 @@ matrix:
           - libboost-all-dev
           - libqrencode-dev
           - libminiupnpc-dev
-          - libminiupnpc8
           - qt4-qmake
           - libqt4-dev
     script: qmake && make -j2
 
   # Build MintCoin-Qt
-  # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
+  # Ubuntu 16.04 LTS (Xenial Xerus) is our latest Ubuntu version
   # Make a 32-bit version using Debian multiarch
   - os: linux
     dist: xenial
@@ -279,22 +251,6 @@ matrix:
     script: /usr/lib/i386-linux-gnu/qt4/bin/qmake && make -j2
 
   # Build MintCoin-Qt
-  # Ubuntu 16.04 LTS (Xenial Xerus) not supported yet
-  #- os: linux
-  #  dist: xenial
-  #  addons:
-  #    apt:
-  #      packages:
-  #        - libdb++-dev
-  #        - libboost-all-dev
-  #        - libqrencode-dev
-  #        - libminiupnpc-dev
-  #        - libminiupnpc8
-  #        - qt4-qmake
-  #        - libqt4-dev
-  #  script: qmake && make -j2 && python src/mega-copy.py MintCoin-Qt $TRAVIS_BRANCH/MintCoin-Qt.linux-ubuntu-xenial
-
-  # Build MintCoin-Qt
   # Cross-compile Windows 32-bit GUI
   - os: linux
     dist: xenial
@@ -307,23 +263,6 @@ matrix:
     dist: xenial
     sudo: required
     script: bash src/mxe-build.sh windows64-qt
-
-  # Build MintCoin-Qt
-  # OS X 10.10 (Yosemite)
-  #  
-  #   Error: You are using macOS 10.10.
-  #   We (and Apple) do not provide support for this old version.
-  #   You may encounter build failures or other breakages.
-
-  # Build MintCoin-Qt
-  # OS X 10.11 (El Capitan)
-  #
-  #   Error: You are using macOS 10.11.
-  #   We (and Apple) do not provide support for this old version.
-  #   You will encounter build failures and other breakages.
-  #   Please create pull requests instead of asking for help on Homebrew's
-  #   GitHub, Discourse, Twitter or IRC. As you are running this old version,
-  #   you are responsible for resolving any issues you experience.
 
   # Build MintCoin-Qt
   # OS X 10.12 (Sierra)

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,4 +235,4 @@ matrix:
   # macOS 10.14 (Mojave)
   - os: osx
     osx_image: xcode10.2
-    script: open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg && brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 
+    script: export MACOSX_DEPLOYMENT_TARGET=10.14 && open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg && brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   # Build mintcoind
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     addons:
       apt:
@@ -28,14 +28,14 @@ matrix:
   # Build mintcoind
   # Cross-compile Windows 32-bit daemon
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     script: bash src/mxe-build.sh windows32
 
   # Build mintcoind
   # Cross-compile Windows 64-bit daemon
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     script: bash src/mxe-build.sh windows64
 
@@ -43,7 +43,7 @@ matrix:
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   # Make a 32-bit version using Debian multiarch
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     # To support 32-bit builds, we add the i386 architecture to
     # Ubuntu, and then install 32-bit versions of the compiler and
@@ -89,7 +89,7 @@ matrix:
   # Build mintcoind static
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     addons:
       apt:
@@ -105,7 +105,7 @@ matrix:
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   # Make a 32-bit version using Debian multiarch
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     # To support 32-bit builds, we add the i386 architecture to
     # Ubuntu, and then install 32-bit versions of the compiler and
@@ -212,7 +212,7 @@ matrix:
   # Build MintCoin-Qt
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     addons:
       apt:
@@ -230,7 +230,7 @@ matrix:
   # Ubuntu 14.04 LTS (Trusty Tahr) is our latest (and only) Ubuntu version
   # Make a 32-bit version using Debian multiarch
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     # To support 32-bit builds, we add the i386 architecture to
     # Ubuntu, and then install 32-bit versions of the compiler and
@@ -297,14 +297,14 @@ matrix:
   # Build MintCoin-Qt
   # Cross-compile Windows 32-bit GUI
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     script: bash src/mxe-build.sh windows32-qt
 
   # Build MintCoin-Qt
   # Cross-compile Windows 64-bit GUI
   - os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     script: bash src/mxe-build.sh windows64-qt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,37 +111,49 @@ matrix:
   # Build mintcoind
   # OS X 10.11 (El Capitan)
   - os: osx
-    osx_image: xcode7.3
+    osx_image: xcode8
     script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
   # OS X 10.11 (El Capitan)
   - os: osx
-    osx_image: xcode7.3
+    osx_image: xcode8
     script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
-  # OS X 10.12 (Sierra)
+  # macOS 10.12 (Sierra)
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode9.2
     script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
-  # OS X 10.12 (Sierra)
+  # macOS 10.12 (Sierra)
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode9.2
     script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
-  # OS X 10.13 (High Sierra)
+  # macOS 10.13 (High Sierra)
   - os: osx
-    osx_image: xcode9.3beta
+    osx_image: xcode10.1
     script: cd src && make -f makefile.osx -j2
 
   # Build mintcoind static
-  # OS X 10.13 (High Sierra)
+  # macOS 10.13 (High Sierra)
   - os: osx
-    osx_image: xcode9.3beta
+    osx_image: xcode10.1
+    script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
+
+  # Build mintcoind
+  # macOS 10.14 (Mojave)
+  - os: osx
+    osx_image: xcode10.2
+    script: cd src && make -f makefile.osx -j2
+
+  # Build mintcoind static
+  # macOS 10.14 (Mojave)
+  - os: osx
+    osx_image: xcode10.2
     script: cd src && make -f makefile.osx -j2 STATIC="all" LDFLAGS="-static"
 
   # Build MintCoin-Qt
@@ -208,13 +220,19 @@ matrix:
     script: bash src/mxe-build.sh windows64-qt
 
   # Build MintCoin-Qt
-  # OS X 10.12 (Sierra)
+  # macOS 10.12 (Sierra)
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode9
     script: brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2
 
   # Build MintCoin-Qt
-  # OS X 10.13 (High Sierra)
+  # macOS 10.13 (High Sierra)
   - os: osx
-    osx_image: xcode9.3beta
+    osx_image: xcode10.1
+    script: brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 
+
+  # Build MintCoin-Qt
+  # macOS 10.14 (Mojave)
+  - os: osx
+    osx_image: xcode10.2
     script: brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,39 +50,20 @@ matrix:
     #
     # https://wiki.debian.org/Multiarch
     #
-    # Even with multiarch support, we have to do a bit of a dance, for
-    # two reasons.
+    # Even with multiarch support, we have to do a bit of a dance.
     #
-    # First, apt-get does not seem to understand dependencies for
-    # the multiarch stuff, so we have to explicitly install all of
-    # the dependencies.
-    #
-    # Second, one of the packages is built for the "all" architecture.
-    # In principle this should work, but for some reason the system
-    # insists that to use it for the MPI libraries it needs to be for
-    # the "i386" architecture. So we download and repackage the .deb
-    # file modified to support this. For details see this Serverfault
-    # message:
-    #
-    # https://serverfault.com/a/383958
-    #
+    # apt-get does not seem to understand dependencies for the
+    # multiarch stuff, so we have to explicitly install all of the
+    # dependencies.
     before_script:
         - sudo dpkg --add-architecture i386
         - sudo apt-get update
-        - sudo apt-get install -y gcc:i386 cpp:i386 gcc-4.8:i386 binutils:i386
-        - sudo apt-get install -y g++:i386
+        - sudo apt-get install -y g++:i386 cpp:i386 gcc:i386 cpp-5:i386 gcc-5:i386 binutils:i386
         - sudo apt-get install -y libssl-dev:i386
         - sudo apt-get install -y libdb++-dev:i386
         - sudo apt-get install -y libminiupnpc-dev:i386
-        - apt-get download openmpi-common:all
-        - ar x openmpi-common_*_all.deb
-        - tar xf control.tar.gz
-        - |
-          sed -i "s/^Architecture: all/Architecture: i386/" control
-        - tar czf control.tar.gz md5sums control
-        - ar rcs openmpi-common_*_all.deb debian-binary control.tar.gz data.tar.xz
-        - sudo dpkg -i openmpi-common_*_all.deb
-        - sudo apt-get install -y libboost-all-dev:i386 libboost-mpi-dev:i386 libboost-mpi-python-dev:i386 libboost-mpi-python1.54-dev:i386 libboost-mpi-python1.54.0:i386 libboost-mpi-python1.54-dev:i386 libboost-mpi1.54-dev:i386 python:i386
+        - sudo apt-get install -y openmpi-common:i386
+        - sudo apt-get install -y libboost-all-dev:i386 libboost-mpi-dev:i386 libboost-mpi-python-dev:i386 libboost-python-dev:i386 libboost-python1.58-dev:i386 python:i386
     script: cd src && make -f makefile.unix -j2
 
   # Build mintcoind static
@@ -111,39 +92,20 @@ matrix:
     #
     # https://wiki.debian.org/Multiarch
     #
-    # Even with multiarch support, we have to do a bit of a dance, for
-    # two reasons.
+    # Even with multiarch support, we have to do a bit of a dance.
     #
-    # First, apt-get does not seem to understand dependencies for
-    # the multiarch stuff, so we have to explicitly install all of
-    # the dependencies.
-    #
-    # Second, one of the packages is built for the "all" architecture.
-    # In principle this should work, but for some reason the system
-    # insists that to use it for the MPI libraries it needs to be for
-    # the "i386" architecture. So we download and repackage the .deb
-    # file modified to support this. For details see this Serverfault
-    # message:
-    #
-    # https://serverfault.com/a/383958
-    #
+    # apt-get does not seem to understand dependencies for the
+    # multiarch stuff, so we have to explicitly install all of the
+    # dependencies.
     before_script:
         - sudo dpkg --add-architecture i386
         - sudo apt-get update
-        - sudo apt-get install -y gcc:i386 cpp:i386 gcc-4.8:i386 binutils:i386
-        - sudo apt-get install -y g++:i386
+        - sudo apt-get install -y g++:i386 cpp:i386 gcc:i386 cpp-5:i386 gcc-5:i386 binutils:i386
         - sudo apt-get install -y libssl-dev:i386
         - sudo apt-get install -y libdb++-dev:i386
         - sudo apt-get install -y libminiupnpc-dev:i386
-        - apt-get download openmpi-common:all
-        - ar x openmpi-common_*_all.deb
-        - tar xf control.tar.gz
-        - |
-          sed -i "s/^Architecture: all/Architecture: i386/" control
-        - tar czf control.tar.gz md5sums control
-        - ar rcs openmpi-common_*_all.deb debian-binary control.tar.gz data.tar.xz
-        - sudo dpkg -i openmpi-common_*_all.deb
-        - sudo apt-get install -y libboost-all-dev:i386 libboost-mpi-dev:i386 libboost-mpi-python-dev:i386 libboost-mpi-python1.54-dev:i386 libboost-mpi-python1.54.0:i386 libboost-mpi-python1.54-dev:i386 libboost-mpi1.54-dev:i386 python:i386
+        - sudo apt-get install -y openmpi-common:i386
+        - sudo apt-get install -y libboost-all-dev:i386 libboost-mpi-dev:i386 libboost-mpi-python-dev:i386 libboost-python-dev:i386 libboost-python1.58-dev:i386 python:i386
     script: cd src && make -f makefile.unix -j2 STATIC="all" LDFLAGS="-static"
 
   # Build mintcoind
@@ -210,39 +172,20 @@ matrix:
     #
     # https://wiki.debian.org/Multiarch
     #
-    # Even with multiarch support, we have to do a bit of a dance, for
-    # two reasons.
+    # Even with multiarch support, we have to do a bit of a dance.
     #
-    # First, apt-get does not seem to understand dependencies for
-    # the multiarch stuff, so we have to explicitly install all of
-    # the dependencies.
-    #
-    # Second, one of the packages is built for the "all" architecture.
-    # In principle this should work, but for some reason the system
-    # insists that to use it for the MPI libraries it needs to be for
-    # the "i386" architecture. So we download and repackage the .deb
-    # file modified to support this. For details see this Serverfault
-    # message:
-    #
-    # https://serverfault.com/a/383958
-    #
+    # apt-get does not seem to understand dependencies for the
+    # multiarch stuff, so we have to explicitly install all of the
+    # dependencies.
     before_script:
         - sudo dpkg --add-architecture i386
         - sudo apt-get update
-        - sudo apt-get install -y gcc:i386 cpp:i386 gcc-4.8:i386 binutils:i386
-        - sudo apt-get install -y g++:i386
+        - sudo apt-get install -y g++:i386 cpp:i386 gcc:i386 cpp-5:i386 gcc-5:i386 binutils:i386
         - sudo apt-get install -y libssl-dev:i386
         - sudo apt-get install -y libdb++-dev:i386
         - sudo apt-get install -y libminiupnpc-dev:i386
-        - apt-get download openmpi-common:all
-        - ar x openmpi-common_*_all.deb
-        - tar xf control.tar.gz
-        - |
-          sed -i "s/^Architecture: all/Architecture: i386/" control
-        - tar czf control.tar.gz md5sums control
-        - ar rcs openmpi-common_*_all.deb debian-binary control.tar.gz data.tar.xz
-        - sudo dpkg -i openmpi-common_*_all.deb
-        - sudo apt-get install -y libboost-all-dev:i386 libboost-mpi-dev:i386 libboost-mpi-python-dev:i386 libboost-mpi-python1.54-dev:i386 libboost-mpi-python1.54.0:i386 libboost-mpi-python1.54-dev:i386 libboost-mpi1.54-dev:i386 python:i386
+        - sudo apt-get install -y openmpi-common:i386
+        - sudo apt-get install -y libboost-all-dev:i386 libboost-mpi-dev:i386 libboost-mpi-python-dev:i386 libboost-python-dev:i386 libboost-python1.58-dev:i386 python:i386
         - sudo apt-get install -y libqrencode-dev:i386
         - sudo apt-get install -y qt4-qmake:i386 libqt4-dev:i386
         - sudo apt-get install -y qtchooser:i386

--- a/.travis.yml
+++ b/.travis.yml
@@ -233,6 +233,6 @@ matrix:
 
   # Build MintCoin-Qt
   # macOS 10.14 (Mojave)
-  - os: osx
-    osx_image: xcode10.2
-    script: export MACOSX_DEPLOYMENT_TARGET=10.14 && open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg && brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 
+  #- os: osx
+  #  osx_image: xcode10.2
+  #  script: export MACOSX_DEPLOYMENT_TARGET=10.14 && open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg && brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,4 +235,4 @@ matrix:
   # macOS 10.14 (Mojave)
   - os: osx
     osx_image: xcode10.2
-    script: brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 
+    script: open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg && brew install qrencode qt && /usr/local/opt/qt/bin/qmake && make -j2 

--- a/mintcoin-qt.pro
+++ b/mintcoin-qt.pro
@@ -141,7 +141,7 @@ else {
     QMAKE_CFLAGS += -msse2
 }
 
-QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector
+QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector
 
 # Input
 DEPENDPATH += src src/json src/qt

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -7,6 +7,18 @@
 
 #include <stdexcept>
 #include <vector>
+
+#ifdef _WINDOWS
+#include <winsock2.h>
+#include <windows.h>
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef X509_CERT_PAIR
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif // _WINDOWS
+
 #include <openssl/bn.h>
 
 #include "util.h" // for uint64

--- a/src/key.h
+++ b/src/key.h
@@ -13,6 +13,16 @@
 #include "uint256.h"
 #include "hash.h"
 
+#ifdef _WINDOWS
+#include <windows.h>
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef X509_CERT_PAIR
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif // _WINDOWS
+
 #include <openssl/ec.h> // for EC_KEY definition
 
 // secp160k1

--- a/src/leveldb/include/leveldb/status.h
+++ b/src/leveldb/include/leveldb/status.h
@@ -13,7 +13,7 @@
 #ifndef STORAGE_LEVELDB_INCLUDE_STATUS_H_
 #define STORAGE_LEVELDB_INCLUDE_STATUS_H_
 
-#include <string>
+#include <string.h>
 #include "leveldb/slice.h"
 
 namespace leveldb {

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -95,7 +95,7 @@ DEBUGFLAGS=-g
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 -pthread -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # If we have an ARM CPU, we can't use SSE2, so define as thumb.

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -95,7 +95,7 @@ DEBUGFLAGS=-g
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 -pthread -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 -pthread -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Werror \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # If we have an ARM CPU, we can't use SSE2, so define as thumb.

--- a/src/mxe-build.sh
+++ b/src/mxe-build.sh
@@ -28,10 +28,10 @@ fi
 # Add the MXE package repository.
 sudo apt-get update
 
-echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" \
+echo "deb https://pkg.mxe.cc/repos/apt xenial main" \
     | sudo tee /etc/apt/sources.list.d/mxeapt.list
 sudo apt-key adv --keyserver keyserver.ubuntu.com \
-    --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+    --recv-keys C6BF758A33A3A276
 
 sudo apt-get update
 


### PR DESCRIPTION
After the MXE package repository went away, our builds failed. After it was brought back, we needed a bit of jiggering in order to get the Windows build working again - including some changes in a few header files.

Since Ubuntu 14.04 LTS (Trusty Tahir) is now end-of-life, I changed all of our Linux builds from Ubuntu 14.04 LTS to Ubuntu 16.04 LTS (Xenial Xerus) - the latest that Travis CI supports.

I also updated all of the macOS builds to the latest versions of XCode available. That brought support for macOS 10.14 (Mojave), although unfortunately the Qt build for 10.14 is still broken. Since we generally want to build with the _oldest_ version of macOS possible, this is not a big deal but should be fixed eventually. Issue #107 tracks the work around that.